### PR TITLE
chore: add Docker Compose skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 .cache/
 
 wordlesolver.egg-info/
+frontend/node_modules/
 
 tests.ipynb
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+COPY pyproject.toml uv.lock ./
+COPY core/ core/
+COPY api/ api/
+
+RUN uv sync --no-dev
+
+EXPOSE 5000
+
+CMD ["uv", "run", "flask", "--app", "api", "run", "--host", "0.0.0.0", "--port", "5000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+    ports:
+      - "5000:5000"
+    volumes:
+      - ./core:/app/core
+      - ./api:/app/api
+    environment:
+      - FLASK_ENV=development
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    environment:
+      - REACT_APP_API_URL=http://localhost:5000
+    depends_on:
+      - api

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary

- `docker-compose.yml` — two services: `api` (Flask, port 5000) and `frontend` (React, port 3000)
- `api/Dockerfile` — Python 3.12-slim + uv, copies core/ and api/, runs Flask
- `frontend/Dockerfile` — Node 22-alpine, runs React dev server
- Volumes mounted for hot reload during development
- `frontend/node_modules/` added to `.gitignore`

## Notes

Both Dockerfiles are stubs — they will work once the actual app code is added in issues #42 (Flask) and #45 (React).

## Test plan

- [ ] `docker compose build` succeeds once #42 and #45 are complete
- [ ] `docker compose up` starts both services
- [ ] Frontend reaches API at `http://localhost:5000`

Closes #38