### PR TITLE
test(cli): add CLI integration tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,4 +21,4 @@ jobs:
 
       - name: Run unit tests
         run: |
-          uv run --extra test pytest tests/
+          uv run --extra test pytest tests/ -m "not slow"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ license = "BSD-3-Clause"
 requires-python = ">=3.12"
 dependencies = [
     "pandas>=3",
+    "click>=8",
 ]
 
 [project.optional-dependencies]
@@ -36,4 +37,7 @@ packages = ["core", "cli", "api"]
 [tool.pytest.ini_options]
 testpaths = [
     "tests/",
+]
+markers = [
+    "slow: marks tests as slow (skipped in CI)",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,44 @@
+import pytest
+from click.testing import CliRunner
+from cli.main import main
+
+
+runner = CliRunner()
+
+
+@pytest.mark.slow
+def test_no_steps_en():
+    result = runner.invoke(main, ["--lang", "en"])
+    assert result.exit_code == 0
+    assert len(result.output.strip()) == 5
+
+
+@pytest.mark.slow
+def test_no_steps_es():
+    result = runner.invoke(main, ["--lang", "es"])
+    assert result.exit_code == 0
+    assert len(result.output.strip()) == 5
+
+
+def test_known_steps_es():
+    result = runner.invoke(main, ["--lang", "es", "--step", "careo", "12110", "--step", "recto", "11120"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "greco"
+
+
+def test_known_steps_en():
+    result = runner.invoke(main, ["--lang", "en", "--step", "tares", "12221", "--step", "moust", "12211"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "smith"
+
+
+def test_invalid_guess():
+    result = runner.invoke(main, ["--lang", "en", "--step", "zzzzz", "00000"])
+    assert result.exit_code != 0
+    assert "zzzzz" in result.output
+
+
+def test_invalid_answer():
+    result = runner.invoke(main, ["--lang", "en", "--step", "tares", "99999"])
+    assert result.exit_code != 0
+    assert "99999" in result.output

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,4 +1,4 @@
-from core.validations import validate_answer, validate_word
+from core.validations import validate_word
 from core.models import Language, Languages
 
 import pytest
@@ -32,29 +32,3 @@ def test_word_not_found(word: str, language: Language):
         validate_word(word, language)
 
 
-@pytest.mark.parametrize(
-    "answer",
-    [
-        "000000",
-        "00003",
-        "coche",
-    ]
-)
-def test_invalid_answer(answer: str):
-    with pytest.raises(ValueError):
-        validate_answer(answer)
-
-
-@pytest.mark.parametrize(
-    "steps, language",
-    [
-        ([("careo", "12110"), ("recto", "11120")], Languages.ES),
-        ([("tares", "12221"), ("moust", "12211")], Languages.EN),
-    ]
-)
-def test_valid_steps(steps: list[tuple], language: Language):
-    from core import Solver
-    solver = Solver(language)
-    for guess, answer in steps:
-        solver.add_step(guess, answer)
-    assert solver.total_possible() >= 0

--- a/tests/test_theory.py
+++ b/tests/test_theory.py
@@ -22,15 +22,7 @@ def test_base_entropy(word: str, value: float, language: Language):
     assert value == entropy(word, all_words)
 
 
-@pytest.mark.skip("Takes too long (5mins) — will resume once processing is more efficient.")
-@pytest.mark.parametrize("language", [Languages.ES, Languages.EN])
-def test_most_entropy(language: Language):
-    all_words = _load_words(language)
-    stats = compute_entropies(all_words, all_words)
-    best = stats.sort_values("entropy", ascending=False).iloc[0]["word"]
-    assert best == language.initial_suggestion
-
-
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "steps, language",
     [

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -203,6 +215,7 @@ name = "wordlesolver"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "pandas" },
 ]
 
@@ -213,6 +226,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8" },
     { name = "pandas", specifier = ">=3" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=9" },
 ]


### PR DESCRIPTION
## Summary

- 6 integration tests via click's `CliRunner` — no subprocess overhead, full CLI→core path exercised
- Regression tests: known step sequences assert exact expected suggestion (`greco` for ES, `smith` for EN)
- Error path tests: invalid guess and invalid answer both exit non-zero with the bad value in output
- Smoke tests (`test_no_steps_*`) marked `@pytest.mark.slow` — skipped in CI, run locally
- Removed dead `test_most_entropy` (referenced `initial_suggestion` which no longer exists)
- Removed redundant `test_invalid_answer` and `test_valid_steps` from `test_exceptions.py`
- `test_parallelism` marked `@pytest.mark.slow`
- CI workflow updated to run `pytest -m "not slow"`

Closes #41