### PR TITLE
feat(api): add solve endpoint and shared parser

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -7,16 +7,17 @@ from werkzeug.exceptions import HTTPException
 
 from api.routes import health_bp, solve_bp
 
+DEFAULT_DEBUG = "false"
+DEFAULT_PORT = "5000"
+FRONTEND_ORIGIN = "http://localhost:3000"
+
 
 def create_app() -> Flask:
     app = Flask(__name__)
-    app.config["DEBUG"] = _to_bool(os.getenv("DEBUG", "false"))
-    app.config["PORT"] = int(os.getenv("PORT", "5000"))
+    app.config["DEBUG"] = _to_bool(os.getenv("DEBUG", DEFAULT_DEBUG))
+    app.config["PORT"] = int(os.getenv("PORT", DEFAULT_PORT))
 
-    CORS(
-        app,
-        resources={r"/*": {"origins": ["http://localhost:3000"]}},
-    )
+    CORS(app, resources={r"/*": {"origins": [FRONTEND_ORIGIN]}})
 
     app.register_blueprint(health_bp)
     app.register_blueprint(solve_bp)

--- a/api/app.py
+++ b/api/app.py
@@ -1,9 +1,11 @@
 import os
 from http import HTTPStatus
 
-from flask import Flask, jsonify
+from flask import Flask
 from flask_cors import CORS
 from werkzeug.exceptions import HTTPException
+
+from api.routes import health_bp, solve_bp
 
 
 def create_app() -> Flask:
@@ -16,9 +18,8 @@ def create_app() -> Flask:
         resources={r"/*": {"origins": ["http://localhost:3000"]}},
     )
 
-    @app.get("/health")
-    def health() -> tuple[dict[str, str], int]:
-        return {"status": "ok"}, HTTPStatus.OK
+    app.register_blueprint(health_bp)
+    app.register_blueprint(solve_bp)
 
     register_error_handlers(app)
     return app

--- a/api/routes/__init__.py
+++ b/api/routes/__init__.py
@@ -1,0 +1,4 @@
+from api.routes.health import health_bp
+from api.routes.solve import solve_bp
+
+__all__ = ["health_bp", "solve_bp"]

--- a/api/routes/health.py
+++ b/api/routes/health.py
@@ -1,0 +1,10 @@
+from http import HTTPStatus
+
+from flask import Blueprint
+
+health_bp = Blueprint("health", __name__)
+
+
+@health_bp.get("/health")
+def health() -> tuple[dict[str, str], int]:
+    return {"status": "ok"}, HTTPStatus.OK

--- a/api/routes/solve.py
+++ b/api/routes/solve.py
@@ -1,0 +1,45 @@
+from http import HTTPStatus
+
+from flask import Blueprint, request
+from werkzeug.exceptions import BadRequest
+
+from core import Solver, parse_language, parse_steps
+
+solve_bp = Blueprint("solve", __name__)
+
+
+@solve_bp.post("/solve")
+def solve() -> tuple[dict[str, object], int]:
+    payload = request.get_json(silent=True)
+    if not isinstance(payload, dict):
+        raise BadRequest("Request body must be a JSON object.")
+
+    try:
+        language = parse_language(payload.get("language"))
+        steps = parse_steps(payload.get("steps"))
+    except ValueError as error:
+        raise BadRequest(str(error)) from error
+
+    solver = Solver(language)
+    for step in steps:
+        try:
+            solver.add_step(step.guess, step.answer)
+        except ValueError as error:
+            raise BadRequest(str(error)) from error
+
+    total_possible = solver.total_possible()
+    if total_possible == 0:
+        raise BadRequest("No possible words remaining. Check your feedback.")
+
+    return (
+        {
+            "best_guess": solver.best_guess(),
+            "possible_words": [
+                {"word": entry["word"], "probability": entry["probability"]}
+                for entry in solver.possible_words()
+            ],
+            "suggestions": solver.suggestions(),
+            "total_possible": total_possible,
+        },
+        HTTPStatus.OK,
+    )

--- a/cli/command.py
+++ b/cli/command.py
@@ -1,19 +1,19 @@
 import click
 
 from core import Solver
-from core.models import Language
+from core.models import Language, Step
 
 
 def _dim(text: str) -> str:
     return click.style(f"  {text}", fg="bright_black")
 
 
-def run(language: Language, steps: list[tuple[str, str]], verbose: bool) -> None:
+def run(language: Language, steps: list[Step], verbose: bool) -> None:
     solver = Solver(language)
 
-    for guess, answer in steps:
+    for step in steps:
         try:
-            solver.add_step(guess, answer)
+            solver.add_step(step.guess, step.answer)
         except ValueError as e:
             raise click.BadParameter(str(e), param_hint="--step")
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -1,6 +1,6 @@
 import click
 
-from core import Languages
+from core import parse_language, parse_steps
 
 
 @click.command()
@@ -8,7 +8,7 @@ from core import Languages
     "--lang",
     default="en",
     show_default=True,
-    type=click.Choice(["en", "es"]),
+    type=str,
     help="Language of the Wordle game."
 )
 @click.option(
@@ -22,15 +22,19 @@ from core import Languages
 @click.option("--verbose", "-v", is_flag=True, help="Show words left, top probable, and top suggestions.")
 def main(lang: str, step: tuple, tui: bool, verbose: bool):
     """Wordle solver — returns the next best guess given accumulated steps."""
-    match lang:
-        case "en":
-            language = Languages.EN
-        case "es":
-            language = Languages.ES
+    try:
+        language = parse_language(lang)
+    except ValueError as error:
+        raise click.BadParameter(str(error), param_hint="--lang") from error
+
+    try:
+        steps = parse_steps(step)
+    except ValueError as error:
+        raise click.BadParameter(str(error), param_hint="--step") from error
 
     if tui:
         from cli.tui import run
-        run(language, step)
+        run(language, steps)
     else:
         from cli.command import run
-        run(language, step, verbose)
+        run(language, steps, verbose)

--- a/cli/tui.py
+++ b/cli/tui.py
@@ -11,7 +11,8 @@
 import click
 
 from core.models import Language
+from core.models import Step
 
 
-def run(language: Language, steps: list[tuple[str, str]]) -> None:
+def run(language: Language, steps: list[Step]) -> None:
     raise click.ClickException("TUI not yet implemented (issue #39).")

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,3 +1,4 @@
 from core.solver import Solver
 from core.models import Language, Languages, Step
 from core.feedback import feedback
+from core.parsing import parse_language, parse_steps

--- a/core/parsing.py
+++ b/core/parsing.py
@@ -1,0 +1,53 @@
+from collections.abc import Mapping, Sequence
+
+from core.models import Language, Languages, Step
+
+
+def parse_language(language_code: object) -> Language:
+    if not isinstance(language_code, str):
+        raise ValueError("'language' is required and must be a string.")
+
+    languages = {
+        "en": Languages.EN,
+        "es": Languages.ES,
+    }
+    language = languages.get(language_code.lower())
+    if language is None:
+        raise ValueError(f"Unsupported language '{language_code}'. Use 'en' or 'es'.")
+
+    return language
+
+
+def parse_steps(raw_steps: object) -> list[Step]:
+    if raw_steps is None:
+        return []
+    if isinstance(raw_steps, (str, bytes)) or not isinstance(raw_steps, Sequence):
+        raise ValueError("'steps' must be a list.")
+
+    parsed_steps: list[Step] = []
+    for index, raw_step in enumerate(raw_steps):
+        parsed_steps.append(_parse_step(raw_step, index))
+
+    return parsed_steps
+
+
+def _parse_step(raw_step: object, index: int) -> Step:
+    if isinstance(raw_step, Step):
+        return raw_step
+
+    if isinstance(raw_step, Mapping):
+        guess = raw_step.get("guess")
+        answer = raw_step.get("answer")
+    elif isinstance(raw_step, Sequence) and not isinstance(raw_step, (str, bytes)):
+        if len(raw_step) != 2:
+            raise ValueError(f"'steps[{index}]' must contain exactly 2 items.")
+        guess, answer = raw_step
+    else:
+        raise ValueError(f"'steps[{index}]' must be an object or pair.")
+
+    if not isinstance(guess, str):
+        raise ValueError(f"'steps[{index}].guess' must be a string.")
+    if not isinstance(answer, str):
+        raise ValueError(f"'steps[{index}].answer' must be a string.")
+
+    return Step(guess=guess, answer=answer)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,56 @@
+from http import HTTPStatus
+
+from api import create_app
+
+
+def test_health():
+    client = create_app().test_client()
+
+    response = client.get("/health")
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.json == {"status": "ok"}
+
+
+def test_solve_happy_path():
+    client = create_app().test_client()
+
+    response = client.post(
+        "/solve",
+        json={"language": "en", "steps": [{"guess": "tares", "answer": "12221"}]},
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert set(response.json) == {"best_guess", "possible_words", "suggestions", "total_possible"}
+    assert isinstance(response.json["best_guess"], str)
+    assert isinstance(response.json["total_possible"], int)
+    assert len(response.json["best_guess"]) == 5
+    assert len(response.json["possible_words"]) <= 10
+    assert len(response.json["suggestions"]) <= 10
+
+
+def test_solve_bad_language():
+    client = create_app().test_client()
+
+    response = client.post("/solve", json={"language": "fr", "steps": []})
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json["error"] == "Bad Request"
+
+
+def test_solve_total_possible_zero():
+    client = create_app().test_client()
+
+    response = client.post(
+        "/solve",
+        json={
+            "language": "en",
+            "steps": [
+                {"guess": "tares", "answer": "00000"},
+                {"guess": "tares", "answer": "11111"},
+            ],
+        },
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert response.json["error"] == "Bad Request"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -31,4 +31,3 @@ def test_word_not_found(word: str, language: Language):
     with pytest.raises(ValueError):
         validate_word(word, language)
 
-

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,42 @@
+import pytest
+
+from core.models import Languages, Step
+from core.parsing import parse_language, parse_steps
+
+
+def test_parse_language_en():
+    assert parse_language("en") == Languages.EN
+
+
+def test_parse_language_es():
+    assert parse_language("es") == Languages.ES
+
+
+def test_parse_language_invalid():
+    with pytest.raises(ValueError, match="Unsupported language"):
+        parse_language("fr")
+
+
+def test_parse_steps_from_cli_tuples():
+    steps = parse_steps([("tares", "12221"), ("moust", "12211")])
+
+    assert steps == [Step("tares", "12221"), Step("moust", "12211")]
+
+
+def test_parse_steps_from_api_objects():
+    steps = parse_steps([
+        {"guess": "tares", "answer": "12221"},
+        {"guess": "moust", "answer": "12211"},
+    ])
+
+    assert steps == [Step("tares", "12221"), Step("moust", "12211")]
+
+
+def test_parse_steps_invalid_shape():
+    with pytest.raises(ValueError, match="must be a list"):
+        parse_steps("not-a-list")
+
+
+def test_parse_steps_invalid_item():
+    with pytest.raises(ValueError, match="must contain exactly 2 items"):
+        parse_steps([("tares", "12221", "extra")])


### PR DESCRIPTION
## Summary
Add Flask solve endpoint, shared parsing, route split, and API tests.

## Changes
- add shared parser for CLI and API input
- add `POST /solve` API endpoint with JSON errors
- split API routes into dedicated files
- add integration tests for `/health` and `/solve`
- tidy Flask app config constants

## Design decisions
- keep `total_possible == 0` as a `400 Bad Request`
- return all solver outputs from one endpoint so solver state is reused
- keep route files small and app factory thin

Closes #43
Closes #44